### PR TITLE
Reverted missing break in parameter validation

### DIFF
--- a/src/wtp.c
+++ b/src/wtp.c
@@ -1354,6 +1354,7 @@ static void wtp_handle_argv(int argc, char **argv) {
 					printf("Invalid -%c argument\n", optopt);
 					exit(1);
 				}
+                break;
 			}
 			
 			case '?': {


### PR DESCRIPTION
Break got lost here: https://github.com/travelping/freewtp/commit/efd9eedd517b082f9f1c49c0d6e301ec5875acd6#diff-c0c632b71d14311261676f7f2874aeb8L1348

> ~ $ wtp -c/etc/capwap/wlan0.conf
> Unknown option character `\x0'
> FreeWTP CAPWAP-WTP daemon
> 
> Usage: capwap-wtp [OPTION...]
> 
>   -h                   show this information
>   -V                   show version information
>   -c CONFIG            use configuration-file CONFIG
