### PR TITLE
wifi_station_clean is called too early

### DIFF
--- a/src/binding/ieee80211/wifi_drivers.c
+++ b/src/binding/ieee80211/wifi_drivers.c
@@ -395,9 +395,6 @@ static void wifi_station_delete(struct wifi_station* station)
 	/* */
 	log_printf(LOG_INFO, "Delete station: " MACSTR, MAC2STR(station->address));
 
-	/* */
-	wifi_station_clean(station);
-
 	/* Delay delete station */
 	station->timeout_action = WIFI_STATION_TIMEOUT_ACTION_DELETE;
 	station->timeout.repeat = WIFI_STATION_TIMEOUT_AFTER_DEAUTHENTICATED / 1000.0;


### PR DESCRIPTION
wifi_station_clean is called in wifi_station_delete and therefor
bypasses the WIFI_STATION_TIMEOUT_ACTION_DELETE. That results in loss of
the wifi deauthentication frame that should be sent before a wifi
station is deleted on AP.